### PR TITLE
fix(tests): fix reanimated mock.js with patch-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "react-native start",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "test": "jest",
+    "postinstall": "patch-package",
     "test:watch": "jest --watch"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "^0.56.0",
+    "patch-package": "6.2.1",
     "prettier": "^1.19.1",
     "react-test-renderer": "16.9.0",
     "typescript": "^3.7.3"

--- a/patches/react-native-reanimated+1.7.0.patch
+++ b/patches/react-native-reanimated+1.7.0.patch
@@ -1,0 +1,24 @@
+diff --git a/node_modules/react-native-reanimated/mock.js b/node_modules/react-native-reanimated/mock.js
+index 43978f5..f2dee0c 100644
+--- a/node_modules/react-native-reanimated/mock.js
++++ b/node_modules/react-native-reanimated/mock.js
+@@ -11,7 +11,9 @@
+ const React = require('react');
+ const { View, Text, Image, Animated } = require('react-native');
+ 
+-function NOOP() {}
++function NOOP() {
++  return { __value: 1}
++}
+ 
+ class Code extends React.Component {
+   render() {
+@@ -109,7 +111,7 @@ module.exports = {
+       }
+     },
+     block: (a) => a[a.length - 1],
+-    call: (a, b) => b(a),
++    call: (a, b) => {},
+     debug: NOOP,
+     onChange: NOOP,
+     startClock: NOOP,

--- a/src/__tests__/__snapshots__/Drawer.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Drawer.test.tsx.snap
@@ -1,0 +1,286 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DrawerNavigator should render properly 1`] = `
+<View
+  collapsable={true}
+  pointerEvents="box-none"
+  style={
+    Object {
+      "flex": 1,
+    }
+  }
+>
+  <View
+    collapsable={false}
+    onGestureHandlerEvent={
+      Object {
+        "__value": 1,
+      }
+    }
+    onGestureHandlerStateChange={
+      Object {
+        "__value": 1,
+      }
+    }
+    style={
+      Object {
+        "flex": 1,
+        "overflow": "hidden",
+      }
+    }
+  >
+    <View
+      importantForAccessibility="yes"
+      style={
+        Array [
+          Object {
+            "flex": 1,
+          },
+          Object {
+            "transform": Array [
+              Object {
+                "translateX": 0,
+              },
+            ],
+          },
+          undefined,
+        ]
+      }
+    >
+      <View
+        style={
+          Object {
+            "flex": 1,
+          }
+        }
+      >
+        <View
+          collapsable={false}
+          pointerEvents="auto"
+          removeClippedSubviews={false}
+          style={
+            Array [
+              Object {
+                "flex": 1,
+                "overflow": "hidden",
+              },
+              Array [
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                },
+                Object {
+                  "opacity": 1,
+                },
+              ],
+            ]
+          }
+        >
+          <View
+            style={
+              Object {
+                "flex": 1,
+              }
+            }
+          >
+            <View>
+              <Text>
+                Test Screen
+              </Text>
+            </View>
+          </View>
+        </View>
+      </View>
+      <View
+        collapsable={false}
+        onGestureHandlerStateChange={
+          Object {
+            "__value": 1,
+          }
+        }
+        style={
+          Array [
+            Object {
+              "backgroundColor": "rgba(0, 0, 0, 0.5)",
+              "bottom": 0,
+              "left": 0,
+              "position": "absolute",
+              "right": 0,
+              "top": 0,
+            },
+            Object {
+              "opacity": Object {
+                "__value": 1,
+              },
+              "zIndex": -1,
+            },
+            Object {
+              "backgroundColor": "rgba(0, 0, 0, 0.5)",
+            },
+          ]
+        }
+      />
+    </View>
+    <View
+      accessibilityViewIsModal={false}
+      removeClippedSubviews={false}
+      style={
+        Array [
+          Object {
+            "backgroundColor": "white",
+            "bottom": 0,
+            "maxWidth": "100%",
+            "position": "absolute",
+            "top": 0,
+            "width": "80%",
+          },
+          Object {
+            "left": AnimatedValue {
+              " __value": NaN,
+            },
+          },
+          Object {
+            "opacity": Object {
+              "setValue": [Function],
+            },
+            "transform": Array [
+              Object {
+                "translateX": NaN,
+              },
+            ],
+            "zIndex": 0,
+          },
+          Object {
+            "backgroundColor": "#fff",
+            "width": 320,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "flex": 1,
+            },
+            undefined,
+          ]
+        }
+      >
+        <ScrollView
+          alwaysBounceVertical={false}
+        >
+          <View
+            pointerEvents="box-none"
+            style={
+              Object {
+                "paddingBottom": 0,
+                "paddingLeft": 0,
+                "paddingRight": 0,
+                "paddingTop": 20,
+              }
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingVertical": 4,
+                  },
+                  undefined,
+                ]
+              }
+            >
+              <TouchableOpacity
+                accessibilityLabel="Home"
+                accessible={true}
+                activeOpacity={0.2}
+                borderless={false}
+                delayPressIn={0}
+                pressColor="rgba(0, 0, 0, .32)"
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "rgba(0, 0, 0, .04)",
+                      "flexDirection": "row",
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "fontWeight": "bold",
+                          "margin": 16,
+                        },
+                        Object {
+                          "color": "#2196f3",
+                        },
+                        undefined,
+                        undefined,
+                      ]
+                    }
+                  >
+                    Home
+                  </Text>
+                </View>
+              </TouchableOpacity>
+              <TouchableOpacity
+                accessibilityLabel="Settings"
+                accessible={true}
+                activeOpacity={0.2}
+                borderless={false}
+                delayPressIn={0}
+                pressColor="rgba(0, 0, 0, .32)"
+              >
+                <View
+                  pointerEvents="box-none"
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "transparent",
+                      "flexDirection": "row",
+                      "paddingBottom": 0,
+                      "paddingLeft": 0,
+                      "paddingRight": 0,
+                      "paddingTop": 0,
+                    }
+                  }
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "fontWeight": "bold",
+                          "margin": 16,
+                        },
+                        Object {
+                          "color": "rgba(0, 0, 0, .87)",
+                        },
+                        undefined,
+                        undefined,
+                      ]
+                    }
+                  >
+                    Settings
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </ScrollView>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1221,6 +1221,11 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 abab@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
@@ -2881,6 +2886,14 @@ find-up@^4.1.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-1.2.1.tgz#40eb8e6e7c2502ddfaa2577c176f221422f860db"
+  integrity sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==
+  dependencies:
+    fs-extra "^4.0.3"
+    micromatch "^3.1.4"
+
 flat-cache@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
@@ -2934,6 +2947,15 @@ fs-extra@^1.0.0:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
+
+fs-extra@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  integrity sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-extra@^7.0.1:
   version "7.0.1"
@@ -4093,6 +4115,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+
 klaw@^1.0.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/klaw/-/klaw-1.3.1.tgz#4088433b46b3b1ba259d78785d8e96f73ba02439"
@@ -5033,6 +5062,24 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+patch-package@6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-6.2.1.tgz#e3c55cf09dffd3984dd300e30d842672b604307f"
+  integrity sha512-dfCtQor63PPij6DDYtCzBRoO5nNAcMSg7Cmh+DLhR+s3t0OLQBdvFxJksZHBe1J2MjsSWDjTF4+oQKFbdkssIg==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^2.4.2"
+    cross-spawn "^6.0.5"
+    find-yarn-workspace-root "^1.2.1"
+    fs-extra "^7.0.1"
+    is-ci "^2.0.0"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.0"
+    rimraf "^2.6.3"
+    semver "^5.6.0"
+    slash "^2.0.0"
+    tmp "^0.0.33"
 
 path-exists@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
I think this was a problem with mock.js distributed in react-native-reanimated. The noop type returned void so it was breaking some mocked functions that actually didn't return void but instead wanted an Animatedvalue. I figured this looking at the stack trace and then the types. And the call mock, I have no idea, I just applied a noop to it because it seems to do something fairly mockable like call a callback.

![Screen Shot 2020-03-03 at 12 43 41 AM](https://user-images.githubusercontent.com/15015324/75741234-beb62e80-5ce8-11ea-8804-e0abf9a791f4.png)
